### PR TITLE
Omit chart if all values are zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use term RPE instead of intensity
 - Improve display of charts when all values are zero
 - Background color of sections on routine page and training session page
+- Omit charts that contain no data
 
 ### Fixed
 

--- a/frontend/src/page/body_fat.rs
+++ b/frontend/src/page/body_fat.rs
@@ -771,6 +771,7 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
             model.interval.last,
             data_model.theme(),
         ),
+        true,
     )
 }
 

--- a/frontend/src/page/body_weight.rs
+++ b/frontend/src/page/body_weight.rs
@@ -393,6 +393,7 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
             None,
             data_model.theme(),
         ),
+        true,
     )
 }
 

--- a/frontend/src/page/exercise.rs
+++ b/frontend/src/page/exercise.rs
@@ -499,7 +499,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Volume load", common::COLOR_VOLUME_LOAD)],
@@ -513,7 +514,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Time under tension (s)", common::COLOR_TUT)],
@@ -524,7 +526,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[
@@ -568,7 +571,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Weight (kg)", common::COLOR_WEIGHT)],
@@ -588,7 +592,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Time (s)", common::COLOR_TIME)],
@@ -607,7 +612,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
     ]
 }

--- a/frontend/src/page/menstrual_cycle.rs
+++ b/frontend/src/page/menstrual_cycle.rs
@@ -361,6 +361,7 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
             Some(4.),
             data_model.theme(),
         ),
+        true,
     )
 }
 

--- a/frontend/src/page/muscles.rs
+++ b/frontend/src/page/muscles.rs
@@ -103,7 +103,8 @@ pub fn view(model: &Model, data_model: &data::Model) -> Node<Msg> {
                             Some(0.),
                             Some(10.),
                             data_model.theme()
-                        )
+                        ),
+                        true,
                     )
                 ]
             })

--- a/frontend/src/page/routine.rs
+++ b/frontend/src/page/routine.rs
@@ -1345,7 +1345,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Set volume", common::COLOR_SET_VOLUME)],
@@ -1359,7 +1360,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("RPE", common::COLOR_RPE)],
@@ -1385,7 +1387,8 @@ pub fn view_charts<Ms>(
                 Some(5.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
     ]
 }

--- a/frontend/src/page/training.rs
+++ b/frontend/src/page/training.rs
@@ -537,7 +537,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("Set volume (weekly total)", common::COLOR_SET_VOLUME)],
@@ -548,7 +549,8 @@ pub fn view_charts<Ms>(
                 Some(0.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
         common::view_chart(
             &[("RPE (weekly average)", common::COLOR_RPE)],
@@ -559,7 +561,8 @@ pub fn view_charts<Ms>(
                 Some(5.),
                 Some(10.),
                 theme,
-            )
+            ),
+            false,
         ),
     ]
 }


### PR DESCRIPTION
Do not show a chart if all values of the data series(es) are zero. Optionally, print a text in place of the chart.

This makes the UI clearer if certain features are not being used (like RPE).

Don't hesitate to request (or make) changes if you think this should be solved differently!