### PR TITLE
Default hard sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve display of charts when all values are zero
 - Background color of sections on routine page and training session page
 - Omit charts that contain no data
+- Hide empty columns in training tables
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Background color of sections on routine page and training session page
 - Omit charts that contain no data
 - Hide empty columns in training tables
+- Consider sets without RPE value to be hard sets
 
 ### Fixed
 

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -654,7 +654,7 @@ impl TrainingSession {
             .iter()
             .filter_map(|e| match e {
                 TrainingSessionElement::Set { rpe, .. } => {
-                    if rpe.unwrap_or(0.0) >= 7.0 {
+                    if rpe.unwrap_or(10.0) >= 7.0 {
                         Some(1)
                     } else {
                         None

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -693,18 +693,21 @@ impl TrainingSession {
         sets.iter().sum::<u32>()
     }
 
-    pub fn tut(&self) -> u32 {
+    pub fn tut(&self) -> Option<u32> {
         let sets = &self
             .elements
             .iter()
             .map(|e| match e {
                 TrainingSessionElement::Set { reps, time, .. } => {
-                    reps.unwrap_or(1) * time.unwrap_or(0)
+                    time.as_ref().map(|v| reps.unwrap_or(1) * v)
                 }
-                _ => 0,
+                _ => None,
             })
             .collect::<Vec<_>>();
-        sets.iter().sum::<u32>()
+        if sets.iter().all(Option::is_none) {
+            return None;
+        }
+        Some(sets.iter().filter_map(|e| *e).sum::<u32>())
     }
 
     pub fn stimulus_per_muscle(&self, exercises: &BTreeMap<u32, Exercise>) -> BTreeMap<u8, u32> {

--- a/frontend/src/page/exercise.rs
+++ b/frontend/src/page/exercise.rs
@@ -461,8 +461,8 @@ pub fn view_charts<Ms>(
             .or_insert(training_session.volume_load() as f32);
         #[allow(clippy::cast_precision_loss)]
         tut.entry(training_session.date)
-            .and_modify(|e| *e += training_session.tut() as f32)
-            .or_insert(training_session.tut() as f32);
+            .and_modify(|e| *e += training_session.tut().unwrap_or(0) as f32)
+            .or_insert(training_session.tut().unwrap_or(0) as f32);
         if let Some(avg_reps) = training_session.avg_reps() {
             reps_rpe
                 .entry(training_session.date)

--- a/frontend/src/page/training.rs
+++ b/frontend/src/page/training.rs
@@ -627,7 +627,7 @@ pub fn view_table<Ms: 'static>(
                         td![&t.set_volume()],
                         td![common::value_or_dash(t.avg_rpe())],
                         td![&t.volume_load()],
-                        td![&t.tut()],
+                        td![common::value_or_dash(t.tut())],
                         td![common::value_or_dash(t.avg_reps())],
                         td![if let (Some(avg_reps), Some(avg_rpe)) = (t.avg_reps(), t.avg_rpe()) {
                             format!("{:.1}", avg_reps + 10.0 - avg_rpe)


### PR DESCRIPTION
This PR

- removes columns (Set volume, RPE, TUT, Reps, Reps+RIR, Weight, Time) in the trainings table if they do not contain any data (i.e. the respective feature hasn't been used)
- makes the training table slightly more consistent by adding dashes for missing "Set volume" entries

In addition, it changes the set volume calculation such that sets without RPE are considered hard sets. Let me know if this is consistent with your usage. There are certainly other options (e.g. a respective configuration option or making the RPE value for hard sets configurable). For now, my idea was to add no configuration options if possible to keep the complexity low.