### PR TITLE
Allow hiding TUT and RPE UI elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Descriptions of measuring points on body fat page
 - Archiving of routines
 - Button for saving changes during guided training session
+- Settings for hiding UI elements related to RPE and TUT
 
 ### Changed
 

--- a/frontend/src/common.rs
+++ b/frontend/src/common.rs
@@ -1220,8 +1220,10 @@ pub fn view_element_with_description<Ms>(element: Node<Ms>, description: &str) -
 pub fn format_set(
     reps: Option<u32>,
     time: Option<u32>,
+    show_tut: bool,
     weight: Option<f32>,
     rpe: Option<f32>,
+    show_rpe: bool,
 ) -> String {
     let mut parts = vec![];
 
@@ -1232,7 +1234,7 @@ pub fn format_set(
     }
 
     if let Some(time) = time {
-        if time > 0 {
+        if show_tut && time > 0 {
             parts.push(format!("{time} s"));
         }
     }
@@ -1246,7 +1248,7 @@ pub fn format_set(
     let mut result = parts.join(" × ");
 
     if let Some(rpe) = rpe {
-        if rpe > 0.0 {
+        if show_rpe && rpe > 0.0 {
             result.push_str(&format!(" @ {rpe}"));
         }
     }

--- a/frontend/src/data.rs
+++ b/frontend/src/data.rs
@@ -22,6 +22,8 @@ pub fn init(url: Url, _orders: &mut impl Orders<Msg>) -> Model {
         theme: Theme::Light,
         automatic_metronome: false,
         notifications: false,
+        show_rpe: true,
+        show_tut: true,
     });
     let ongoing_training_session =
         gloo_storage::LocalStorage::get(STORAGE_KEY_ONGOING_TRAINING_SESSION).unwrap_or(None);
@@ -425,11 +427,14 @@ pub enum TrainingSessionElement {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub beep_volume: u8,
     pub theme: Theme,
     pub automatic_metronome: bool,
     pub notifications: bool,
+    pub show_rpe: bool,
+    pub show_tut: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
@@ -1104,6 +1109,8 @@ pub enum Msg {
     SetTheme(Theme),
     SetAutomaticMetronome(bool),
     SetNotifications(bool),
+    SetShowRPE(bool),
+    SetShowTUT(bool),
 
     StartTrainingSession(u32),
     UpdateTrainingSession(usize, TimerState),
@@ -1972,6 +1979,14 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         }
         Msg::SetNotifications(value) => {
             model.settings.notifications = value;
+            local_storage_set(STORAGE_KEY_SETTINGS, &model.settings, &mut model.errors);
+        }
+        Msg::SetShowRPE(value) => {
+            model.settings.show_rpe = value;
+            local_storage_set(STORAGE_KEY_SETTINGS, &model.settings, &mut model.errors);
+        }
+        Msg::SetShowTUT(value) => {
+            model.settings.show_tut = value;
             local_storage_set(STORAGE_KEY_SETTINGS, &model.settings, &mut model.errors);
         }
 

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -257,6 +257,8 @@ enum Msg {
     SetTheme(data::Theme),
     ToggleAutomaticMetronome,
     ToggleNotifications,
+    ToggleShowRPE,
+    ToggleShowTUT,
     UpdateApp,
     GoUp,
     LogOut,
@@ -358,6 +360,18 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                     .send_msg(Msg::Data(data::Msg::SetNotifications(true)));
             }
         },
+        Msg::ToggleShowRPE => {
+            orders.send_msg(Msg::Data(data::Msg::SetShowRPE(not(model
+                .data
+                .settings
+                .show_rpe))));
+        }
+        Msg::ToggleShowTUT => {
+            orders.send_msg(Msg::Data(data::Msg::SetShowTUT(not(model
+                .data
+                .settings
+                .show_tut))));
+        }
         Msg::UpdateApp => {
             orders.skip().send_msg(Msg::Data(data::Msg::UpdateApp));
         }
@@ -770,6 +784,56 @@ fn view_settings_dialog(data_model: &data::Model) -> Node<Msg> {
                     } else {
                         "Manual"
                     },
+                ],
+            ],
+            p![
+                C!["mb-5"],
+                h1![C!["subtitle"], "Rating of Perceived Exertion (RPE)"],
+                div![
+                    C!["field"],
+                    C!["is-grouped"],
+                    div![
+                        C!["control"],
+                        button![
+                            C!["button"],
+                            if data_model.settings.show_rpe {
+                                C!["is-primary"]
+                            } else {
+                                C![]
+                            },
+                            ev(Ev::Click, |_| Msg::ToggleShowRPE),
+                            if data_model.settings.show_rpe {
+                                "Enabled"
+                            } else {
+                                "Disabled"
+                            },
+                        ]
+                    ],
+                ],
+            ],
+            p![
+                C!["mb-5"],
+                h1![C!["subtitle"], "Time Under Tension (TUT)"],
+                div![
+                    C!["field"],
+                    C!["is-grouped"],
+                    div![
+                        C!["control"],
+                        button![
+                            C!["button"],
+                            if data_model.settings.show_tut {
+                                C!["is-primary"]
+                            } else {
+                                C![]
+                            },
+                            ev(Ev::Click, |_| Msg::ToggleShowTUT),
+                            if data_model.settings.show_tut {
+                                "Enabled"
+                            } else {
+                                "Disabled"
+                            },
+                        ]
+                    ],
                 ],
             ],
             {


### PR DESCRIPTION
This PR introduces settings to hide the UI elements for TUT and RPE. I use neither of those during training and regularly find myself entering the values for reps and load in the wrong fields. The change is only in the UI - the data remains untouched. Settings default to showing those UI elements so that, by default, the UI looks as before.

I ended up using buttons to control the respective settings. I also played around with check boxes, but those don't look great and I had trouble getting them to work in seed. Let me know what you think.

Closes senier/valens#5