### PR TITLE
Add function to insert previous sets values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Button for saving changes during guided training session
 - Settings for hiding UI elements related to RPE and TUT
 - Option to prefer exercise in training session
+- Shortcut for inserting values of previous set into current set
 
 ### Changed
 


### PR DESCRIPTION
This MR adds a shortcut to show and insert the values of the previous set (of the same session) into the current set. This avoids scrolling up (especially in super sets) to see the values that have been achieved in the previous set of the same exercise.