### PR TITLE
Display rest time field if TUT display if disabled

### DIFF
--- a/frontend/src/page/routine.rs
+++ b/frontend/src/page/routine.rs
@@ -1072,7 +1072,7 @@ fn view_routine_part(
                                 ]
                             ],
                             IF![
-                                show_tut =>
+                                show_tut || exercise_id.is_none() =>
                                 div![
                                     C!["field"],
                                     C!["mb-0"],


### PR DESCRIPTION
This is a bug fix related to #58. One time related field (the rest time in the exercise routine editor) got hidden unintentionally.