### PR TITLE
Refactor chart plotting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ $(addprefix frontend/dist/,$(FRONTEND_FILES)): third-party/bulma third-party/fon
 .PHONY: run run_frontend run_backend
 
 run:
-	tmux new-window $(MAKE) run_frontend
-	tmux new-window $(MAKE) run_backend
+	tmux new-window $(MAKE) CONFIG_FILE=$(CONFIG_FILE) run_frontend
+	tmux new-window $(MAKE) CONFIG_FILE=$(CONFIG_FILE) run_backend
 
 run_frontend:
 	PATH=~/.cargo/bin:${PATH} trunk --config frontend/Trunk.toml serve --port 8000

--- a/frontend/src/ui/page/body_fat.rs
+++ b/frontend/src/ui/page/body_fat.rs
@@ -96,7 +96,7 @@ pub enum Msg {
     DateChanged(String),
     ChestChanged(String),
     AbdominalChanged(String),
-    TighChanged(String),
+    ThighChanged(String),
     TricepChanged(String),
     SubscapularChanged(String),
     SuprailiacChanged(String),
@@ -270,7 +270,7 @@ pub fn update(
                 panic!();
             }
         },
-        Msg::TighChanged(thigh) => match model.dialog {
+        Msg::ThighChanged(thigh) => match model.dialog {
             Dialog::AddBodyFat(ref mut form) | Dialog::EditBodyFat(ref mut form) => {
                 match thigh.parse::<u8>() {
                     Ok(parsed_thigh) => {
@@ -551,7 +551,7 @@ fn view_body_fat_dialog(dialog: &Dialog, loading: bool, sex: u8) -> Node<Msg> {
                                 "Thigh",
                                 "Vertical fold midway between knee cap and top of thigh",
                                 &form.thigh,
-                                Msg::TighChanged,
+                                Msg::ThighChanged,
                                 save_disabled
                             ),
                         ]
@@ -575,7 +575,7 @@ fn view_body_fat_dialog(dialog: &Dialog, loading: bool, sex: u8) -> Node<Msg> {
                                 "Thigh",
                                 "Vertical fold midway between knee cap and top of thigh",
                                 &form.thigh,
-                                Msg::TighChanged,
+                                Msg::ThighChanged,
                                 save_disabled
                             ),
                         ]
@@ -834,7 +834,7 @@ fn view_table(model: &Model, data_model: &data::Model) -> Node<Msg> {
                     nodes![
                         th!["Tricep (mm)"],
                         th!["Suprailiac (mm)"],
-                        th!["Tigh (mm)"],
+                        th!["Thigh (mm)"],
                         th!["Chest (mm)"],
                         th!["Abdominal (mm)"],
                         th!["Subscapular (mm)"],
@@ -844,7 +844,7 @@ fn view_table(model: &Model, data_model: &data::Model) -> Node<Msg> {
                     nodes![
                         th!["Chest (mm)"],
                         th!["Abdominal (mm)"],
-                        th!["Tigh (mm)"],
+                        th!["Thigh (mm)"],
                         th!["Tricep (mm)"],
                         th!["Subscapular (mm)"],
                         th!["Suprailiac (mm)"],

--- a/frontend/src/ui/page/body_fat.rs
+++ b/frontend/src/ui/page/body_fat.rs
@@ -742,30 +742,33 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
             ("Weight (kg)", common::COLOR_BODY_WEIGHT),
         ]
         .as_slice(),
-        common::plot_dual_line_chart(
+        common::plot_chart(
             &[
-                (
-                    body_fat
+                common::PlotData {
+                    values: body_weight
+                        .iter()
+                        .map(|bw| (bw.date, bw.weight))
+                        .collect::<Vec<_>>(),
+                    plots: common::plot_line_with_dots(common::COLOR_BODY_WEIGHT),
+                    params: common::PlotParams::SECONDARY,
+                },
+                common::PlotData {
+                    values: body_fat
                         .iter()
                         .filter_map(|bf| bf.jp3(sex).map(|jp3| (bf.date, jp3)))
                         .collect::<Vec<_>>(),
-                    common::COLOR_BODY_FAT_JP3,
-                ),
-                (
-                    body_fat
+                    plots: common::plot_line_with_dots(common::COLOR_BODY_FAT_JP3),
+                    params: common::PlotParams::default(),
+                },
+                common::PlotData {
+                    values: body_fat
                         .iter()
                         .filter_map(|bf| bf.jp7(sex).map(|jp7| (bf.date, jp7)))
                         .collect::<Vec<_>>(),
-                    common::COLOR_BODY_FAT_JP7,
-                ),
+                    plots: common::plot_line_with_dots(common::COLOR_BODY_FAT_JP7),
+                    params: common::PlotParams::default(),
+                },
             ],
-            &[(
-                body_weight
-                    .iter()
-                    .map(|bw| (bw.date, bw.weight))
-                    .collect::<Vec<_>>(),
-                common::COLOR_BODY_WEIGHT,
-            )],
             model.interval.first,
             model.interval.last,
             data_model.theme(),

--- a/frontend/src/ui/page/body_weight.rs
+++ b/frontend/src/ui/page/body_weight.rs
@@ -361,10 +361,10 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
             ("Avg. weight (kg)", common::COLOR_AVG_BODY_WEIGHT),
         ]
         .as_slice(),
-        common::plot_line_chart(
+        common::plot_chart(
             &[
-                (
-                    data_model
+                common::PlotData {
+                    values: data_model
                         .body_weight
                         .values()
                         .filter(|bw| {
@@ -372,10 +372,11 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
                         })
                         .map(|bw| (bw.date, bw.weight))
                         .collect::<Vec<_>>(),
-                    common::COLOR_BODY_WEIGHT,
-                ),
-                (
-                    data_model
+                    plots: common::plot_line_with_dots(common::COLOR_BODY_WEIGHT),
+                    params: common::PlotParams::default(),
+                },
+                common::PlotData {
+                    values: data_model
                         .body_weight_stats
                         .values()
                         .filter(|bws| {
@@ -383,13 +384,12 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
                         })
                         .filter_map(|bws| bws.avg_weight.map(|avg_weight| (bws.date, avg_weight)))
                         .collect::<Vec<_>>(),
-                    common::COLOR_AVG_BODY_WEIGHT,
-                ),
+                    plots: common::plot_line_with_dots(common::COLOR_AVG_BODY_WEIGHT),
+                    params: common::PlotParams::default(),
+                },
             ],
             model.interval.first,
             model.interval.last,
-            None,
-            None,
             data_model.theme(),
         ),
         true,

--- a/frontend/src/ui/page/exercise.rs
+++ b/frontend/src/ui/page/exercise.rs
@@ -513,7 +513,7 @@ pub fn view_charts<Ms>(
     )];
 
     if show_rpe {
-        labels.push(("+ Repetititions in reserve", common::COLOR_REPS_RIR));
+        labels.push(("+ Repetitions in reserve", common::COLOR_REPS_RIR));
         data.push((
             reps_rpe
                 .into_iter()

--- a/frontend/src/ui/page/exercise.rs
+++ b/frontend/src/ui/page/exercise.rs
@@ -501,21 +501,22 @@ pub fn view_charts<Ms>(
 
     let mut labels = vec![("Repetitions", common::COLOR_REPS)];
 
-    let mut data = vec![(
-        reps_rpe
+    let mut data = vec![common::PlotData {
+        values: reps_rpe
             .iter()
             .map(|(date, (avg_reps, _))| {
                 #[allow(clippy::cast_precision_loss)]
                 (*date, avg_reps.iter().sum::<f32>() / avg_reps.len() as f32)
             })
             .collect::<Vec<_>>(),
-        common::COLOR_REPS,
-    )];
+        plots: common::plot_line_with_dots(common::COLOR_REPS),
+        params: common::PlotParams::primary_range(0., 10.),
+    }];
 
     if show_rpe {
         labels.push(("+ Repetitions in reserve", common::COLOR_REPS_RIR));
-        data.push((
-            reps_rpe
+        data.push(common::PlotData {
+            values: reps_rpe
                 .into_iter()
                 .filter_map(|(date, (avg_reps_values, avg_rpe_values))| {
                     #[allow(clippy::cast_precision_loss)]
@@ -530,37 +531,36 @@ pub fn view_charts<Ms>(
                     }
                 })
                 .collect::<Vec<_>>(),
-            common::COLOR_REPS_RIR,
-        ));
+            plots: common::plot_line_with_dots(common::COLOR_REPS_RIR),
+            params: common::PlotParams::primary_range(0., 10.),
+        });
     }
 
     nodes![
         common::view_chart(
             &[("Set volume", common::COLOR_SET_VOLUME)],
-            common::plot_line_chart(
-                &[(
-                    set_volume.into_iter().collect::<Vec<_>>(),
-                    common::COLOR_SET_VOLUME,
-                )],
+            common::plot_chart(
+                &[common::PlotData {
+                    values: set_volume.into_iter().collect::<Vec<_>>(),
+                    plots: common::plot_line_with_dots(common::COLOR_SET_VOLUME),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
         ),
         common::view_chart(
             &[("Volume load", common::COLOR_VOLUME_LOAD)],
-            common::plot_line_chart(
-                &[(
-                    volume_load.into_iter().collect::<Vec<_>>(),
-                    common::COLOR_VOLUME_LOAD,
-                )],
+            common::plot_chart(
+                &[common::PlotData {
+                    values: volume_load.into_iter().collect::<Vec<_>>(),
+                    plots: common::plot_line_with_dots(common::COLOR_VOLUME_LOAD),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
@@ -568,12 +568,14 @@ pub fn view_charts<Ms>(
         IF![show_tut =>
             common::view_chart(
                 &[("Time under tension (s)", common::COLOR_TUT)],
-                common::plot_line_chart(
-                    &[(tut.into_iter().collect::<Vec<_>>(), common::COLOR_TUT,)],
+                common::plot_chart(
+                    &[common::PlotData {
+                        values: tut.into_iter().collect::<Vec<_>>(),
+                        plots: common::plot_line_with_dots(common::COLOR_TUT),
+                        params: common::PlotParams::primary_range(0., 10.),
+                    }],
                     interval.first,
                     interval.last,
-                    Some(0.),
-                    Some(10.),
                     theme,
                 ),
                 false,
@@ -581,33 +583,25 @@ pub fn view_charts<Ms>(
         ],
         common::view_chart(
             &labels,
-            common::plot_line_chart(
-                &data,
-                interval.first,
-                interval.last,
-                Some(0.),
-                Some(10.),
-                theme,
-            ),
+            common::plot_chart(&data, interval.first, interval.last, theme),
             false,
         ),
         common::view_chart(
             &[("Weight (kg)", common::COLOR_WEIGHT)],
-            common::plot_line_chart(
-                &[(
-                    weight
+            common::plot_chart(
+                &[common::PlotData {
+                    values: weight
                         .into_iter()
                         .map(|(date, values)| {
                             #[allow(clippy::cast_precision_loss)]
                             (date, values.iter().sum::<f32>() / values.len() as f32)
                         })
                         .collect::<Vec<_>>(),
-                    common::COLOR_WEIGHT,
-                )],
+                    plots: common::plot_line_with_dots(common::COLOR_WEIGHT),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
@@ -615,20 +609,19 @@ pub fn view_charts<Ms>(
         IF![show_tut =>
             common::view_chart(
                 &[("Time (s)", common::COLOR_TIME)],
-                common::plot_line_chart(
-                    &[(
-                        time.into_iter()
+                common::plot_chart(
+                    &[common::PlotData{
+                        values: time.into_iter()
                             .map(|(date, values)| {
                                 #[allow(clippy::cast_precision_loss)]
                                 (date, values.iter().sum::<f32>() / values.len() as f32)
                             })
                             .collect::<Vec<_>>(),
-                        common::COLOR_TIME,
-                    )],
+                        plots: common::plot_line_with_dots(common::COLOR_TIME),
+                        params: common::PlotParams::primary_range(0., 10.)
+                    }],
                     interval.first,
                     interval.last,
-                    Some(0.),
-                    Some(10.),
                     theme,
                 ),
                 false,

--- a/frontend/src/ui/page/menstrual_cycle.rs
+++ b/frontend/src/ui/page/menstrual_cycle.rs
@@ -345,19 +345,17 @@ fn view_chart(model: &Model, data_model: &data::Model) -> Node<Msg> {
 
     common::view_chart(
         vec![("Intensity", common::COLOR_PERIOD_INTENSITY)].as_slice(),
-        common::plot_bar_chart(
-            &[(
-                period
+        common::plot_chart(
+            &[common::PlotData {
+                values: period
                     .iter()
                     .map(|p| (p.date, f32::from(p.intensity)))
                     .collect::<Vec<_>>(),
-                common::COLOR_PERIOD_INTENSITY,
-            )],
-            &[],
+                plots: [common::PlotType::Histogram(common::COLOR_PERIOD_INTENSITY)].to_vec(),
+                params: common::PlotParams::primary_range(0., 4.),
+            }],
             model.interval.first,
             model.interval.last,
-            Some(0.),
-            Some(4.),
             data_model.theme(),
         ),
         true,

--- a/frontend/src/ui/page/muscles.rs
+++ b/frontend/src/ui/page/muscles.rs
@@ -97,12 +97,14 @@ pub fn view(model: &Model, data_model: &data::Model) -> Node<Msg> {
                     ],
                     common::view_chart(
                         &[("Set volume (weekly total)", common::COLOR_SET_VOLUME)],
-                        common::plot_line_chart(
-                            &[(set_volume, common::COLOR_SET_VOLUME)],
+                        common::plot_chart(
+                            &[common::PlotData {
+                                values: set_volume,
+                                plots: common::plot_line_with_dots(common::COLOR_SET_VOLUME),
+                                params: common::PlotParams::primary_range(0., 10.),
+                            }],
                             model.interval.first,
                             model.interval.last,
-                            Some(0.),
-                            Some(10.),
                             data_model.theme()
                         ),
                         true,

--- a/frontend/src/ui/page/routine.rs
+++ b/frontend/src/ui/page/routine.rs
@@ -1338,27 +1338,28 @@ pub fn view_charts<Ms>(
     nodes![
         common::view_chart(
             &[("Load", common::COLOR_LOAD)],
-            common::plot_line_chart(
-                &[(load.into_iter().collect::<Vec<_>>(), common::COLOR_LOAD)],
+            common::plot_chart(
+                &[common::PlotData {
+                    values: load.into_iter().collect::<Vec<_>>(),
+                    plots: common::plot_line_with_dots(common::COLOR_LOAD),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
         ),
         common::view_chart(
             &[("Set volume", common::COLOR_SET_VOLUME)],
-            common::plot_line_chart(
-                &[(
-                    set_volume.into_iter().collect::<Vec<_>>(),
-                    common::COLOR_SET_VOLUME,
-                )],
+            common::plot_chart(
+                &[common::PlotData {
+                    values: set_volume.into_iter().collect::<Vec<_>>(),
+                    plots: common::plot_line_with_dots(common::COLOR_SET_VOLUME),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
@@ -1367,9 +1368,9 @@ pub fn view_charts<Ms>(
             show_rpe =>
             common::view_chart(
                 &[("RPE", common::COLOR_RPE)],
-                common::plot_line_chart(
-                    &[(
-                        rpe.into_iter()
+                common::plot_chart(
+                    &[common::PlotData{
+                        values: rpe.into_iter()
                             .map(|(date, values)| {
                                 #[allow(clippy::cast_precision_loss)]
                                 (
@@ -1382,12 +1383,11 @@ pub fn view_charts<Ms>(
                                 )
                             })
                             .collect::<Vec<_>>(),
-                        common::COLOR_RPE,
-                    )],
+                        plots: common::plot_line_with_dots(common::COLOR_RPE),
+                        params: common::PlotParams::primary_range(5., 10.)
+                    }],
                     interval.first,
                     interval.last,
-                    Some(5.),
-                    Some(10.),
                     theme,
                 ),
                 false,

--- a/frontend/src/ui/page/training.rs
+++ b/frontend/src/ui/page/training.rs
@@ -528,29 +528,45 @@ pub fn view_charts<Ms>(
                 ("Short-term load", common::COLOR_LOAD),
                 ("Long-term load", common::COLOR_LONG_TERM_LOAD)
             ],
-            common::plot_line_chart(
+            common::plot_chart(
                 &[
-                    (long_term_load_low, common::COLOR_LONG_TERM_LOAD_BOUNDS),
-                    (long_term_load_high, common::COLOR_LONG_TERM_LOAD_BOUNDS),
-                    (long_term_load, common::COLOR_LONG_TERM_LOAD),
-                    (short_term_load, common::COLOR_LOAD)
+                    common::PlotData {
+                        values: long_term_load_low,
+                        plots: common::plot_line_with_dots(common::COLOR_LONG_TERM_LOAD_BOUNDS),
+                        params: common::PlotParams::primary_range(0., 10.),
+                    },
+                    common::PlotData {
+                        values: long_term_load_high,
+                        plots: common::plot_line_with_dots(common::COLOR_LONG_TERM_LOAD_BOUNDS),
+                        params: common::PlotParams::primary_range(0., 10.),
+                    },
+                    common::PlotData {
+                        values: long_term_load,
+                        plots: common::plot_line_with_dots(common::COLOR_LONG_TERM_LOAD),
+                        params: common::PlotParams::primary_range(0., 10.),
+                    },
+                    common::PlotData {
+                        values: short_term_load,
+                        plots: common::plot_line_with_dots(common::COLOR_LOAD),
+                        params: common::PlotParams::primary_range(0., 10.),
+                    }
                 ],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
         ),
         common::view_chart(
             &[("Set volume (weekly total)", common::COLOR_SET_VOLUME)],
-            common::plot_line_chart(
-                &[(total_set_volume_per_week, common::COLOR_SET_VOLUME)],
+            common::plot_chart(
+                &[common::PlotData {
+                    values: total_set_volume_per_week,
+                    plots: common::plot_line_with_dots(common::COLOR_SET_VOLUME),
+                    params: common::PlotParams::primary_range(0., 10.),
+                }],
                 interval.first,
                 interval.last,
-                Some(0.),
-                Some(10.),
                 theme,
             ),
             false,
@@ -559,12 +575,13 @@ pub fn view_charts<Ms>(
             show_rpe =>
             common::view_chart(
                 &[("RPE (weekly average)", common::COLOR_RPE)],
-                common::plot_line_chart(
-                    &[(avg_rpe_per_week, common::COLOR_RPE)],
+                common::plot_chart(
+                    &[common::PlotData{values: avg_rpe_per_week,
+                        plots: common::plot_line_with_dots(common::COLOR_RPE),
+                        params: common::PlotParams::primary_range(5., 10.)
+                    }],
                     interval.first,
                     interval.last,
-                    Some(5.),
-                    Some(10.),
                     theme,
                 ),
                 false,

--- a/tests/backend/cli_test.py
+++ b/tests/backend/cli_test.py
@@ -65,3 +65,13 @@ def test_main_demo_public(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(demo, "run", lambda x, y, z: demo_called.append(1))
     assert cli.main() == 0
     assert demo_called
+
+
+def test_main_demo_db_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_file = tmp_path / "db"
+    db_file.touch()
+    monkeypatch.setattr(sys, "argv", ["valens", "demo", "--database", str(db_file)])
+    demo_called = []
+    monkeypatch.setattr(demo, "run", lambda x, y, z: demo_called.append(1))
+    assert cli.main() == 2
+    assert not demo_called


### PR DESCRIPTION
This PR is in preparation of the changes discussed in #63.

The chart plotting functions got refactored to remove code duplication and make plotting more flexible. Plots can now be done as lines, circles or histograms in any combination on the primary as well as the secondary axis (or both at once).

Plots should look exactly the same as before (this appears to be true for demo data as well as my real world data).

Additionally:
  - some typos fixed
  - allow exporting the demo database
  - allow setting the configuration to be used in the Makefile